### PR TITLE
fix: Fixing ios authentication issues

### DIFF
--- a/src/ToDo.UI/App.xaml.cs
+++ b/src/ToDo.UI/App.xaml.cs
@@ -1,9 +1,5 @@
 #pragma warning disable 109 // Remove warning for Window property on iOS
 
-using ToDo.Business;
-using ToDo.Business.Services;
-using ToDo.Views.Dialogs;
-using Uno.Extensions.Http;
 
 namespace ToDo;
 
@@ -57,6 +53,7 @@ public sealed partial class App : Application
 				.ConfigureServices((context, services) =>
 				{
 					services
+						.AddScoped<IDispatcher, Dispatcher>()
 						.AddEndpoints(context)
 						.AddServices();
 				})

--- a/src/ToDo.UI/Dispatcher.cs
+++ b/src/ToDo.UI/Dispatcher.cs
@@ -1,0 +1,11 @@
+public class Dispatcher : IDispatcher
+{
+	private readonly Window _window;
+	public Dispatcher(Window window)
+	{
+		_window = window;
+	}
+
+	public Task Run(Func<Task> action) => _window.DispatcherQueue.Run(action);
+	public Task<TResult> Run<TResult>(Func<Task<TResult>> actionWithResult) => _window.DispatcherQueue.Run(actionWithResult);
+}

--- a/src/ToDo.UI/GlobalUsings.cs
+++ b/src/ToDo.UI/GlobalUsings.cs
@@ -22,9 +22,13 @@ global using Uno.Extensions.Navigation.Toolkit;
 global using Uno.Extensions.Navigation.Regions;
 global using ToDo.Presentation;
 global using ToDo.Views;
+global using ToDo.Business;
+global using ToDo.Views.Dialogs;
+global using ToDo;
+
 
 #if WINUI
-	global using Microsoft.UI.Dispatching;
+global using Microsoft.UI.Dispatching;
 	global using Microsoft.UI.Xaml;
 	global using Microsoft.UI.Xaml.Controls;
 	global using Microsoft.UI.Xaml.Controls.Primitives;

--- a/src/ToDo.iOS/Info.plist
+++ b/src/ToDo.iOS/Info.plist
@@ -56,5 +56,18 @@
 	<string>{320, 568}</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>MSAL</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>msal980ca8cd-56ec-47dc-972f-a28ccb78e232</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/src/ToDo.iOS/ToDo.iOS.csproj
+++ b/src/ToDo.iOS/ToDo.iOS.csproj
@@ -12,6 +12,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <ResourcesDirectory>..\ToDo.UI\Strings</ResourcesDirectory>
+    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -212,7 +213,7 @@
     </ImageAsset>
   </ItemGroup>
   <ItemGroup>
-    <BundleResource Include="appsettings.platform.json" />
+    <EmbeddedResource Include="appsettings.platform.json" />
     <None Include="Info.plist" />
     <None Include="Entitlements.plist" />
     <BundleResource Include="Resources\Fonts\Roboto-Light.ttf" />

--- a/src/ToDo/IDispatcher.cs
+++ b/src/ToDo/IDispatcher.cs
@@ -1,0 +1,9 @@
+﻿
+namespace ToDo;
+
+public interface IDispatcher
+{
+	Task Run(Func<Task> action);
+
+	Task<TResult> Run<TResult>(Func<Task<TResult>> actionWithResult);
+}

--- a/src/ToDo/Presentation/WelcomeViewModel.cs
+++ b/src/ToDo/Presentation/WelcomeViewModel.cs
@@ -6,20 +6,27 @@ public partial class WelcomeViewModel
 {
 	private readonly IAuthenticationService _authService;
 	private readonly INavigator _navigator;
-
+	private readonly IDispatcher _dispatcher;
 	private WelcomeViewModel(
+		IDispatcher dispatcher,
 		INavigator navigator,
 		ICommandBuilder getStarted,
 		IAuthenticationService authService)
     {
-		_navigator=navigator;
+		_dispatcher = dispatcher;
+		_navigator =navigator;
 		_authService = authService;
 		getStarted.Execute(GetStarted);
 	}
 
 	private async ValueTask GetStarted(CancellationToken ct)
 	{
-		var token = await _authService.AcquireTokenAsync();
+		var token =
+			await _dispatcher.Run(async () =>
+			{
+				return await _authService.AcquireTokenAsync();
+			});
+
 
 		if(!string.IsNullOrWhiteSpace(token?.AccessToken))
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): #93 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Launching the app on ios shows a blank screen. 

A couple of issues:
- Keychain group wasn't being found because the platform resource file was set as bundle resource instead of embedded resource
- MSAL Auth couldn't be launched from background thread
- Keychain access wasn't enabled because entitlements.plist wasn't set as a project property
- msal redirect uri wasn't being set in info.plist 

## What is the new behavior?

You can now launch the app, welcome page shows, you can click get started button to launch authentication.... this process works now on ios

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
