### PR TITLE
fix: Getting wasm to display in release mode

### DIFF
--- a/src/ToDo.Wasm/LinkerConfig.xml
+++ b/src/ToDo.Wasm/LinkerConfig.xml
@@ -1,35 +1,8 @@
 <linker>
 	<assembly fullname="ToDo" />
 	<assembly fullname="ToDo.Wasm" />
-	<assembly fullname="Uno.WinUI" />
-	<assembly fullname="Uno.Extensions.Core" />
-	<assembly fullname="Uno.Extensions.Configuration" />
-	<assembly fullname="Uno.Extensions.Hosting" />
-	<assembly fullname="Uno.Extensions.Hosting.WinUI.Wasm" />
-	<assembly fullname="Uno.Extensions.Http" />
-	<assembly fullname="Uno.Extensions.Localization" />
-	<assembly fullname="Uno.Extensions.Logging" />
-	<assembly fullname="Uno.Extensions.Logging.Serilog" />
-	<assembly fullname="Uno.Extensions.Logging.WinUI.Wasm" />
-	<assembly fullname="Uno.Extensions.Navigation" />
-	<assembly fullname="Uno.Extensions.Navigation.Toolkit.WinUI" />
-	<assembly fullname="Uno.Extensions.Navigation.WinUI" />
-	<assembly fullname="Uno.Extensions.Serialization" />
-	<assembly fullname="Uno.Extensions.Reactive" />
-	<assembly fullname="Uno.Extensions.Reactive.WinUI" />
-	<assembly fullname="Uno.Extensions.Serialization" />
-	<assembly fullname="Uno.Extensions.Serialization.Http" />
-	<assembly fullname="Uno.Extensions.Serialization.Refit" />
-	<assembly fullname="Serilog.Sinks.Console" />
-	<assembly fullname="Serilog.Sinks.Debug" />
-	<assembly fullname="Serilog.Sinks.File" />
-	<assembly fullname="Microsoft.Extensions.Options" />
-	<assembly fullname="Microsoft.Extensions.Hosting" />
-	<assembly fullname="Microsoft.Extensions.Logging" />
-	<assembly fullname="Microsoft.Extensions.Logging.Configuration" />
-	<assembly fullname="Microsoft.Extensions.Logging.Console" />
-	<assembly fullname="Microsoft.Extensions.Logging.Debug" />
-	<assembly fullname="Microsoft.Extensions.Logging.EventSource" />
+	<assembly fullname="Refit" />
+	<!--<assembly fullname="Refit.HttpClientFactory" />-->
 
 	<assembly fullname="System.Core">
 		<!-- This is required by JSon.NET and any expression.Compile caller -->

--- a/src/ToDo.Wasm/LinkerConfig.xml
+++ b/src/ToDo.Wasm/LinkerConfig.xml
@@ -2,7 +2,6 @@
 	<assembly fullname="ToDo" />
 	<assembly fullname="ToDo.Wasm" />
 	<assembly fullname="Refit" />
-	<!--<assembly fullname="Refit.HttpClientFactory" />-->
 
 	<assembly fullname="System.Core">
 		<!-- This is required by JSon.NET and any expression.Compile caller -->


### PR DESCRIPTION
GitHub Issue (If applicable): #142

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Wasm in staging (release mode) doesn't load task lists or tasks (no api calls beyond auth)

## What is the new behavior?

Wasm loads task lists correctly in release mode

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
