### PR TITLE
fix: The "Delete" & "Rename" AppBar buttons should not be visible on "Important" and "Tasks" lists

### DIFF
--- a/src/ToDo.UI/Views/TaskListPage.xaml
+++ b/src/ToDo.UI/Views/TaskListPage.xaml
@@ -19,6 +19,11 @@
 											 TasksValue="{StaticResource MaterialPrimaryVariantLightBrush}"
 											 DefaultValue="{StaticResource MaterialPrimaryVariantLightBrush}" />
 
+		<converters:TaskListToValueConverter x:Key="TaskListVisibilityConverter"
+											 ImportantValue="Collapsed"
+											 TasksValue="Collapsed"
+											 DefaultValue="Visible" />
+
 		<x:String x:Key="Icon_Add">F1 M 14 8 L 8 8 L 8 14 L 6 14 L 6 8 L 0 8 L 0 6 L 6 6 L 6 0 L 8 0 L 8 6 L 14 6 L 14 8 Z</x:String>
 		<x:String x:Key="Icon_Delete_Outline">F1 M 1 16 C 1 17.100000023841858 1.899999976158142 18 3 18 L 11 18 C 12.100000023841858 18 13 17.100000023841858 13 16 L 13 4 L 1 4 L 1 16 Z M 3 6 L 11 6 L 11 16 L 3 16 L 3 6 Z M 10.5 1 L 9.5 0 L 4.5 0 L 3.5 1 L 0 1 L 0 3 L 14 3 L 14 1 L 10.5 1 Z</x:String>
 		<x:String x:Key="Icon_Drive_File_Rename_Outline">F1 M 15.40999984741211 1.7950000762939453 L 14.200000762939453 0.5849999785423279 C 13.420000791549683 -0.19499999284744263 12.149999856948853 -0.19499999284744263 11.369999885559082 0.5849999785423279 L 8.6899995803833 3.2649998664855957 L 0 11.954999923706055 L 0 15.994999885559082 L 4.039999961853027 15.994999885559082 L 12.779999732971191 7.255000114440918 L 15.40999984741211 4.625 C 16.19999986886978 3.8450000286102295 16.19999986886978 2.575000047683716 15.40999984741211 1.7950000762939453 L 15.40999984741211 1.7950000762939453 Z M 3.2100000381469727 13.994999885559082 L 2 13.994999885559082 L 2 12.785000801086426 L 10.65999984741211 4.125 L 11.869999885559082 5.335000038146973 L 3.2100000381469727 13.994999885559082 Z M 8 15.994999885559082 L 12 11.994999885559082 L 18 11.994999885559082 L 18 15.994999885559082 L 8 15.994999885559082 Z</x:String>
@@ -154,13 +159,15 @@
 					</utu:NavigationBar.MainCommand>
 					<utu:NavigationBar.PrimaryCommands>
 						<AppBarButton Command="{Binding RenameList}"
-									  Foreground="{ThemeResource MaterialOnPrimaryMediumBrush}">
+									  Foreground="{ThemeResource MaterialOnPrimaryMediumBrush}"
+									  Visibility="{Binding Entity.Value, Converter={StaticResource TaskListVisibilityConverter}}">
 							<AppBarButton.Icon>
 								<PathIcon Data="{StaticResource Icon_Drive_File_Rename_Outline}" />
 							</AppBarButton.Icon>
 						</AppBarButton>
 						<AppBarButton Command="{Binding DeleteList}"
-									  Foreground="{ThemeResource MaterialOnPrimaryMediumBrush}">
+									  Foreground="{ThemeResource MaterialOnPrimaryMediumBrush}"
+									  Visibility="{Binding Entity.Value, Converter={StaticResource TaskListVisibilityConverter}}">
 							<AppBarButton.Icon>
 								<PathIcon Data="{StaticResource Icon_Delete_Outline}" />
 							</AppBarButton.Icon>


### PR DESCRIPTION
GitHub Issue (If applicable): closes #141 


## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Fix the fact that the "Delete" & "Rename" AppBar buttons should not be visible on "Important" and "Tasks" lists

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
