### PR TITLE
chore(clean up): behaviors to entities and add a clear Search method …

### DIFF
--- a/src/ToDo/Business/ITaskService.cs
+++ b/src/ToDo/Business/ITaskService.cs
@@ -12,5 +12,7 @@ public interface ITaskService
 
 	ValueTask<IImmutableList<ToDoTask>> GetAsync(TaskList list, CancellationToken ct);
 
-	ValueTask<IImmutableList<ToDoTask>> GetAllAsync(string displayName = "", CancellationToken ct = default);
+	ValueTask<IImmutableList<ToDoTask>> GetAllAsync(CancellationToken ct = default);
+
+	ValueTask<IImmutableList<ToDoTask>> SearchAsync(string displayName = "", CancellationToken ct = default);
 }

--- a/src/ToDo/Business/Models/TaskList.cs
+++ b/src/ToDo/Business/Models/TaskList.cs
@@ -36,4 +36,6 @@ public record TaskList
 	public bool IsShared { get; init; }
 
 	public string? WellknownListName { get; init; }
+
+	public bool IsWellKnown => WellknownListName is null or "none";
 }

--- a/src/ToDo/Business/TaskService.cs
+++ b/src/ToDo/Business/TaskService.cs
@@ -58,11 +58,20 @@ public class TaskService : ITaskService
 	}
 
 	/// <inheritdoc />
-	public async ValueTask<IImmutableList<ToDoTask>> GetAllAsync(string displayName = "", CancellationToken ct = default)
+	public async ValueTask<IImmutableList<ToDoTask>> GetAllAsync(CancellationToken ct = default)
 	{
-		var response = await (displayName is { Length: > 0 }
-			? _client.GetByFilterAsync(displayName, ct)
-			: _client.GetAllAsync(ct));
+		var response = await _client.GetAllAsync(ct);
+
+		return (response.Value ?? Enumerable.Empty<TaskData>())
+			.Where(data => data.ParentList?.Id is not null)
+			.Select(data => new ToDoTask(data.ParentList!.Id!, data))
+			.ToImmutableList();
+	}
+
+	/// <inheritdoc />
+	public async ValueTask<IImmutableList<ToDoTask>> SearchAsync(string displayName = "", CancellationToken ct = default)
+	{
+		var response = await _client.GetByFilterAsync(displayName, ct);
 
 		return (response.Value ?? Enumerable.Empty<TaskData>())
 			.Where(data => data.ParentList?.Id is not null)

--- a/src/ToDo/Presentation/HomeViewModel.cs
+++ b/src/ToDo/Presentation/HomeViewModel.cs
@@ -36,7 +36,7 @@ public partial class HomeViewModel
 
 	public TaskList[] WellKnownLists { get; }
 
-	public IListFeed<TaskList> CustomLists => Lists.Where(list => list is { WellknownListName: null or "none" });
+	public IListFeed<TaskList> CustomLists => Lists.Where(list => !list.IsWellKnown);
 
 	public ICommand CreateTaskList => Command.Async(DoCreateTaskList);
 	private async ValueTask DoCreateTaskList(CancellationToken ct)

--- a/src/ToDo/Presentation/SearchViewModel.cs
+++ b/src/ToDo/Presentation/SearchViewModel.cs
@@ -14,7 +14,7 @@ public partial class SearchViewModel
 
 	public IListFeed<ToDoTask> Results => Term
 		.Where(term => term is { Length: > 0 })
-		.SelectAsync(_svc.GetAllAsync)
+		.SelectAsync(_svc.SearchAsync)
 		.AsListFeed();
 
 	public ICommand ToggleIsCompleted => Command.Create<ToDoTask>(c => c.Then(DoToggleIsCompleted));


### PR DESCRIPTION
…for task

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Other : clean up

## What is the current behavior?

no change


## What is the new behavior?

no change


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
