### PR TITLE
fix: Fix task list empty

### DIFF
--- a/src/ToDo/Business/ITaskService.cs
+++ b/src/ToDo/Business/ITaskService.cs
@@ -12,5 +12,5 @@ public interface ITaskService
 
 	ValueTask<IImmutableList<ToDoTask>> GetAllAsync(TaskList list, CancellationToken ct);
 
-	ValueTask<IImmutableList<ToDoTask>> SearchAsync(string displayName, CancellationToken ct);
+	ValueTask<IImmutableList<ToDoTask>> SearchAsync(string term, CancellationToken ct);
 }


### PR DESCRIPTION
## Bugfix
Tasks list is empty when using the API (while there are some items when using mocked data).

## What is the current behavior?
We filter out Task that doesn't have a ListID while this is fulfill only by few API calls.

## What is the new behavior?
When we do have the List as parameter of the API call, we make sure to use it.
