### PR TITLE
fix: input validations

### DIFF
--- a/src/ToDo.UI/App.xaml
+++ b/src/ToDo.UI/App.xaml
@@ -38,7 +38,7 @@
 						</ResourceDictionary>
 					</ResourceDictionary.ThemeDictionaries>
 				</ResourceDictionary>
-				
+
 				<!-- Application's custom styles -->
 				<ResourceDictionary Source="ms-appx:///Styles/FeedView.xaml" />
 				<ResourceDictionary Source="ms-appx:///Styles/NavigationBar.xaml" />
@@ -55,6 +55,12 @@
 
 			<converters:FormatConverter x:Key="FormatConverter" />
 			<converters:StringFormatter x:Key="StringFormatter" />
+			<converters:StringCompareConverter x:Key="IsNullOrEmpty" Comparison="IsNullOrEmpty" />
+			<converters:StringCompareConverter x:Key="IsNullOrWhitespace" Comparison="IsNullOrWhitespace" />
+			<converters:StringCompareConverter x:Key="IsEqualToParameterValue" Comparison="IsEqualToParameterValue" />
+			<converters:StringCompareConverter x:Key="IsNotNullNorEmpty" Comparison="IsNullOrEmpty" InvertResult="True" />
+			<converters:StringCompareConverter x:Key="IsNotNullNorWhitespace" Comparison="IsNullOrWhitespace" InvertResult="True" />
+			<converters:StringCompareConverter x:Key="IsNotEqualToParameterValue" Comparison="IsEqualToParameterValue" InvertResult="True" />
 			<converters:ReferenceConverter x:Key="IsNull" ConversionMode="IsNull" />
 			<converters:ReferenceConverter x:Key="IsNotNull" ConversionMode="IsNotNull" />
 

--- a/src/ToDo.UI/Converters/StringCompareConverter.cs
+++ b/src/ToDo.UI/Converters/StringCompareConverter.cs
@@ -1,0 +1,53 @@
+﻿namespace ToDo.Converters;
+
+/// <summary>
+/// This converter allows for common string comparison operations on the value.
+/// </summary>
+/// <remarks>
+/// Non-string value can be treated as string by setting the <see cref="ConvertToString" /> flag.
+/// </remarks>
+public class StringCompareConverter : IValueConverter
+{
+	public enum ComparisonMethod { IsNullOrEmpty, IsNullOrWhitespace, IsEqualToParameterValue }
+
+	public ComparisonMethod Comparison { get; set; }
+
+	/// <summary>
+	/// Indicates whether <see cref="object.ToString()" /> should be used on the value when it is not a string.
+	/// </summary>
+	public bool ConvertToString { get; set; } = false;
+
+	/// <summary>
+	/// Indicates whether the final result should be inverted, returning <see cref="FalseValue"/> when the comparison is successful, and vice-versa.
+	/// </summary>
+	public bool InvertResult { get; set; } = false;
+
+	/// <summary>
+	/// Value to returned when the comparison is successful. The default value is literal <see cref="true"/>.
+	/// </summary>
+	public object TrueValue { get; set; } = true;
+	
+	/// <summary>
+	/// Value to returned when the comparison is not successful. The default value is literal <see cref="false"/>.
+	/// </summary>
+	public object FalseValue { get; set; } = false;
+
+	public object Convert(object value, Type targetType, object parameter, string language)
+	{
+		var str = value as string ?? (ConvertToString ? value?.ToString() : default);
+		var result = Comparison switch
+		{
+			ComparisonMethod.IsEqualToParameterValue when parameter is string param => str?.Equals(param) == true,
+			ComparisonMethod.IsNullOrEmpty => string.IsNullOrEmpty(str),
+			ComparisonMethod.IsNullOrWhitespace => string.IsNullOrWhiteSpace(str),
+
+			_ => throw new ArgumentOutOfRangeException($"Comparison: {Comparison}"),
+		};
+		result = InvertResult ? !result : result;
+
+		return result ? TrueValue : FalseValue;
+	}
+
+	public object ConvertBack(object value, Type targetType, object parameter, string language)
+		=> throw new NotSupportedException("Only one-way conversion is supported.");
+}

--- a/src/ToDo.UI/ToDo.UI.projitems
+++ b/src/ToDo.UI/ToDo.UI.projitems
@@ -35,6 +35,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Converters\FormatConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ReferenceConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converters\StringCompareConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\StringFormatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\TaskListToValueConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReactiveClasses.cs" />

--- a/src/ToDo.UI/Views/Dialogs/AddListFlyout.xaml
+++ b/src/ToDo.UI/Views/Dialogs/AddListFlyout.xaml
@@ -48,6 +48,7 @@
 					uen:Navigation.Request="-"
 					uen:Navigation.Data="{Binding Text, ElementName=ListNameText}"
 					utu:AutoLayout.CounterAlignment="Start"
+					IsEnabled="{Binding ElementName=ListNameText, Path=Text, Converter={StaticResource IsNotNullNorWhitespace}}"
 					Style="{StaticResource FilledButtonStyle}">
 				<um:ControlExtensions.Icon>
 					<PathIcon Data="{StaticResource Icon_Add}" />

--- a/src/ToDo.UI/Views/Dialogs/AddTaskFlyout.xaml
+++ b/src/ToDo.UI/Views/Dialogs/AddTaskFlyout.xaml
@@ -24,7 +24,7 @@
 
 		<TextBox x:Uid="AddTaskFlyout_InputTextBox"
 				 PlaceholderText="Add a task"
-				 x:Name="TaskText"
+				 x:Name="InputTextBox"
 				 Text="{Binding Title, Mode=TwoWay}"
 				 Style="{StaticResource FilledTextBoxStyle}" />
 
@@ -44,8 +44,9 @@
 			<Button x:Uid="AddTaskFlyout_CreateButton"
 					Content="Create"
 					uen:Navigation.Request="-"
-					uen:Navigation.Data="{Binding Text, ElementName=TaskText}"
+					uen:Navigation.Data="{Binding ElementName=InputTextBox, Path=Text}"
 					utu:AutoLayout.CounterAlignment="Start"
+					IsEnabled="{Binding ElementName=InputTextBox, Path=Text, Converter={StaticResource IsNotNullNorWhitespace}}"
 					Style="{StaticResource FilledButtonStyle}" />
 		</utu:AutoLayout>
 	</utu:AutoLayout>

--- a/src/ToDo.UI/Views/Dialogs/RenameListFlyout.xaml
+++ b/src/ToDo.UI/Views/Dialogs/RenameListFlyout.xaml
@@ -16,15 +16,15 @@
 					Background="{ThemeResource SurfaceBrush}">
 
 		<TextBlock x:Uid="RenameListFlyout_Title"
-			Foreground="{ThemeResource OnSurfaceBrush}"
+				   Foreground="{ThemeResource OnSurfaceBrush}"
 				   TextWrapping="Wrap"
 				   Text="Rename list"
 				   Style="{StaticResource TitleLarge}" />
 
 		<TextBox x:Uid="RenameListFlyout_InputTextBox"
-				 x:Name="ListNameText"
+				 x:Name="InputTextBox"
 				 PlaceholderText="Rename list"
-				 Text="{Binding ListName, Mode=TwoWay}"
+				 Text="{Binding Entity.DisplayName, Mode=OneTime}"
 				 Style="{StaticResource FilledTextBoxStyle}" />
 
 		<utu:AutoLayout Spacing="10" Orientation="Horizontal">
@@ -45,6 +45,7 @@
 					uen:Navigation.Request="-"
 					uen:Navigation.Data="{Binding Text, ElementName=ListNameText}"
 					utu:AutoLayout.CounterAlignment="Start"
+					IsEnabled="{Binding ElementName=InputTextBox, Path=Text, Converter={StaticResource IsNotNullNorWhitespace}}"
 					Style="{StaticResource FilledButtonStyle}" />
 
 		</utu:AutoLayout>

--- a/src/ToDo/Presentation/Dialogs/RenameListViewModel.cs
+++ b/src/ToDo/Presentation/Dialogs/RenameListViewModel.cs
@@ -1,6 +1,3 @@
 namespace ToDo.Presentation.Dialogs;
 
-public partial class RenameListViewModel
-{
-    
-}
+public partial record RenameListViewModel(TaskList Entity);

--- a/src/ToDo/Presentation/TaskListViewModel.cs
+++ b/src/ToDo/Presentation/TaskListViewModel.cs
@@ -93,7 +93,7 @@ public partial class TaskListViewModel
 	public ICommand RenameList => Command.Create(c => c.Given(Entity).Then(DoRenameList));
 	private async ValueTask DoRenameList(TaskList list, CancellationToken ct)
 	{
-		var response = await _navigator.NavigateViewModelForResultAsync<RenameListViewModel, string>(this, qualifier: Qualifiers.Dialog, cancellation: ct);
+		var response = await _navigator.NavigateViewModelForResultAsync<RenameListViewModel, string>(this, qualifier: Qualifiers.Dialog, data: list, cancellation: ct);
 		if (response is null)
 		{
 			return;


### PR DESCRIPTION
GitHub Issue (If applicable): closes #222, closes #262

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

Rename List now have the input prefilled.
Add List/Task now refuses whitespace or empty name.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
<!-- Please provide any additional information if necessary -->