### PR TITLE
feat: Tidying up dialog code and theme switching code

### DIFF
--- a/src/ToDo.UI/App.xaml.cs
+++ b/src/ToDo.UI/App.xaml.cs
@@ -57,6 +57,10 @@ public sealed partial class App : Application
 		_window.Activate();
 
 		await Task.Run(() => _host.StartAsync());
+
+		var appSettings = _host.Services.GetRequiredService<IWritableOptions<ToDoApp>>();
+		var isDark = appSettings.Value?.IsDark ?? false;
+		SystemThemeHelper.SetRootTheme(_window.Content.XamlRoot, isDark);
 	}
 
 	/// <summary>

--- a/src/ToDo.UI/App.xaml.host.cs
+++ b/src/ToDo.UI/App.xaml.host.cs
@@ -5,8 +5,6 @@
 
 #pragma warning disable 109 // Remove warning for Window property on iOS
 
-using ToDo.Business.Models;
-using ToDo.Configuration;
 
 namespace ToDo;
 
@@ -49,6 +47,8 @@ public sealed partial class App : Application
 				// Load OAuth configuration
 				.UseConfiguration<Auth>()
 
+				.UseSettings<ToDoApp>()
+
 				// Register Json serializers (ISerializer and IStreamSerializer)
 				.UseSerialization()
 
@@ -56,6 +56,7 @@ public sealed partial class App : Application
 				.ConfigureServices(
 					(context, services) =>
 						services
+							.AddScoped<IAppTheme, AppTheme>()
 							.AddEndpoints(context, useMocks: useMocks)
 							.AddServices(useMocks: useMocks)
 						)
@@ -157,5 +158,21 @@ public sealed partial class App : Application
 				new(Dialog.ConfirmSignOut, confirmSignOutDialog)
 			})
 		);
+	}
+}
+// TODO: Extract these to uno extensions
+
+public class AppTheme:IAppTheme
+{
+	private readonly Window _window;
+	public AppTheme(Window window)
+	{
+		_window = window;
+	}
+	public bool IsDark => SystemThemeHelper.IsRootInDarkMode(_window.Content.XamlRoot);
+
+	public void SetTheme(bool darkMode)
+	{
+		SystemThemeHelper.SetRootTheme(_window.Content.XamlRoot, darkMode);
 	}
 }

--- a/src/ToDo.UI/App.xaml.host.cs
+++ b/src/ToDo.UI/App.xaml.host.cs
@@ -47,6 +47,7 @@ public sealed partial class App : Application
 				// Load OAuth configuration
 				.UseConfiguration<Auth>()
 
+				// Enable app settings
 				.UseSettings<ToDoApp>()
 
 				// Register Json serializers (ISerializer and IStreamSerializer)
@@ -160,19 +161,4 @@ public sealed partial class App : Application
 		);
 	}
 }
-// TODO: Extract these to uno extensions
 
-public class AppTheme:IAppTheme
-{
-	private readonly Window _window;
-	public AppTheme(Window window)
-	{
-		_window = window;
-	}
-	public bool IsDark => SystemThemeHelper.IsRootInDarkMode(_window.Content.XamlRoot);
-
-	public void SetTheme(bool darkMode)
-	{
-		SystemThemeHelper.SetRootTheme(_window.Content.XamlRoot, darkMode);
-	}
-}

--- a/src/ToDo.UI/App.xaml.host.cs
+++ b/src/ToDo.UI/App.xaml.host.cs
@@ -85,8 +85,8 @@ public sealed partial class App : Application
 		{
 			return new LocalizableMessageDialogViewMap
 			(
-				Content: localizer => localizer![ResourceKey("Content")],
-				Title: localizer => localizer![ResourceKey("Title")],
+				Content: localizer => localizer![ResourceKey(ResourceKeys.DialogContent)],
+				Title: localizer => localizer![ResourceKey(ResourceKeys.DialogTitle)],
 				DelayUserInput: delayUserInput,
 				DefaultButtonIndex: defaultButtonIndex,
 				Buttons: buttons
@@ -100,12 +100,11 @@ public sealed partial class App : Application
 			}
 		}
 
-		var deleteButton = (DialogResults.Affirmative, "./Dialog_Common_Delete");
-		var cancelButton = (DialogResults.Negative, "./Dialog_Common_Cancel");
-		var confirmDeleteListDialog = BuildDialogViewMap("ConfirmDeleteList", true, 0, deleteButton, cancelButton);
-		var confirmDeleteTaskDialog = BuildDialogViewMap("ConfirmDeleteTask", true, 0, deleteButton, cancelButton);
-		var confirmDeleteNoteDialog = BuildDialogViewMap("ConfirmDeleteNote", true, 0, deleteButton, cancelButton);
-		var confirmSignOutDialog = BuildDialogViewMap("ConfirmSignOut", true, 0, (DialogResults.Affirmative, "SignOut"), cancelButton);
+		var deleteButton = (DialogResults.Affirmative, ResourceKeys.DeleteButton);
+		var cancelButton = (DialogResults.Negative, ResourceKeys.CancelButton);
+		var confirmDeleteListDialog = BuildDialogViewMap(Dialog.ConfirmDeleteList, true, 0, deleteButton, cancelButton);
+		var confirmDeleteTaskDialog = BuildDialogViewMap(Dialog.ConfirmDeleteTask, true, 0, deleteButton, cancelButton);
+		var confirmSignOutDialog = BuildDialogViewMap(Dialog.ConfirmSignOut, true, 0, (DialogResults.Affirmative, ResourceKeys.SignOutButton), cancelButton);
 
 		views.Register(
 			/// Dialogs and Flyouts
@@ -123,11 +122,10 @@ public sealed partial class App : Application
 			new ViewMap<WelcomePage, WelcomeViewModel.BindableWelcomeViewModel>(),
 			new ViewMap<TaskListPage, TaskListViewModel.BindableTaskListViewModel>(Data: new DataMap<TaskList>()),
 			new ViewMap(
-				ViewSelector: () => (App.Current as App)?.Window?.Content?.ActualSize.X > (double)App.Current.Resources["WideMinWindowWidth"] ? typeof(TaskControl) : typeof(TaskPage),
+				ViewSelector: () => (App.Current as App)?.Window?.Content?.ActualSize.X > (double)App.Current.Resources[ResourceKeys.WideMinWindowWidth] ? typeof(TaskControl) : typeof(TaskPage),
 				ViewModel: typeof(TaskViewModel.BindableTaskViewModel), Data: new DataMap<ToDoTask>()),
 			confirmDeleteListDialog,
 			confirmDeleteTaskDialog,
-			confirmDeleteNoteDialog,
 			confirmSignOutDialog
 		);
 
@@ -154,10 +152,9 @@ public sealed partial class App : Application
 				new("AddList", View: views.FindByViewModel<AddListViewModel>()),
 				new("ExpirationDate", View: views.FindByViewModel<ExpirationDateViewModel>()),
 				new("RenameList", View: views.FindByViewModel<RenameListViewModel>()),
-				new("ConfirmDeleteList", confirmDeleteListDialog),
-				new("ConfirmDeleteTask", confirmDeleteTaskDialog),
-				new("ConfirmDeleteNote", confirmDeleteNoteDialog),
-				new("ConfirmSignOut", confirmSignOutDialog)
+				new(Dialog.ConfirmDeleteList, confirmDeleteListDialog),
+				new(Dialog.ConfirmDeleteTask, confirmDeleteTaskDialog),
+				new(Dialog.ConfirmSignOut, confirmSignOutDialog)
 			})
 		);
 	}

--- a/src/ToDo.UI/AppTheme.cs
+++ b/src/ToDo.UI/AppTheme.cs
@@ -1,0 +1,18 @@
+﻿namespace ToDo;
+
+// TODO: Extract these to uno extensions
+// See https://github.com/unoplatform/uno.extensions/discussions/420
+public class AppTheme : IAppTheme
+{
+	private readonly Window _window;
+	public AppTheme(Window window)
+	{
+		_window = window;
+	}
+	public bool IsDark => SystemThemeHelper.IsRootInDarkMode(_window.Content.XamlRoot);
+
+	public void SetTheme(bool darkMode)
+	{
+		SystemThemeHelper.SetRootTheme(_window.Content.XamlRoot, darkMode);
+	}
+}

--- a/src/ToDo.UI/AppTheme.cs
+++ b/src/ToDo.UI/AppTheme.cs
@@ -5,14 +5,19 @@
 public class AppTheme : IAppTheme
 {
 	private readonly Window _window;
-	public AppTheme(Window window)
+	private readonly IDispatcher _dispatcher;
+	public AppTheme(Window window, IDispatcher dispatcher)
 	{
 		_window = window;
+		_dispatcher = dispatcher;
 	}
 	public bool IsDark => SystemThemeHelper.IsRootInDarkMode(_window.Content.XamlRoot);
 
-	public void SetTheme(bool darkMode)
+	public async Task SetThemeAsync(bool darkMode)
 	{
-		SystemThemeHelper.SetRootTheme(_window.Content.XamlRoot, darkMode);
+		await _dispatcher.ExecuteAsync(() =>
+		{
+			SystemThemeHelper.SetRootTheme(_window.Content.XamlRoot, darkMode);
+		});
 	}
 }

--- a/src/ToDo.UI/GlobalUsings.cs
+++ b/src/ToDo.UI/GlobalUsings.cs
@@ -22,6 +22,7 @@ global using Uno.Extensions.Localization;
 global using Uno.Extensions.Serialization;
 global using Uno.Extensions.Navigation.Toolkit;
 global using Uno.Extensions.Navigation.Regions;
+global using Uno.Toolkit.UI;
 global using ToDo.Views;
 global using ToDo.Views.Dialogs;
 global using ToDo.Business;

--- a/src/ToDo.UI/ReactiveClasses.cs
+++ b/src/ToDo.UI/ReactiveClasses.cs
@@ -62,19 +62,8 @@ public class ReactiveRouteResolver : RouteResolver
 		var viewFunc = (drm.View?.View is not null) ?
 										() => drm.View.View :
 										drm.View?.ViewSelector;
-		return new RouteInfo(
-			Path: drm.Path,
-			View: viewFunc,
-			ViewAttributes: drm.View?.ViewAttributes,
-			ViewModel: (drm.View is ReactiveViewMap rvmp)?rvmp.BindableViewModel: drm.View?.ViewModel,
-			Data: drm.View?.Data?.Data,
-			ToQuery: drm.View?.Data?.UntypedToQuery,
-			FromQuery: drm.View?.Data?.UntypedFromQuery,
-			ResultData: drm.View?.ResultData,
-			IsDefault: drm.IsDefault,
-			DependsOn: drm.DependsOn,
-			Init: drm.Init,
-			Nested: ResolveViewMaps(drm.Nested));
+		return base.FromRouteMap(drm) with {
+			ViewModel = (drm.View is ReactiveViewMap rvmp) ? rvmp.BindableViewModel : drm.View?.ViewModel };
 	}
 
 	public override RouteInfo? FindByViewModel(Type? viewModelType)

--- a/src/ToDo.UI/Strings/Resources.l12n.xml
+++ b/src/ToDo.UI/Strings/Resources.l12n.xml
@@ -300,12 +300,12 @@
 			<fr>Mode</fr>
 			<es>Tema</es>
 		</data>
-		<data name="ThemeLight.Content">
+		<data name="ThemeLight">
 			<en>Light</en>
 			<fr>Clair</fr>
 			<es>Claro</es>
 		</data>
-		<data name="ThemeDark.Content">
+		<data name="ThemeDark">
 			<en>Dark</en>
 			<fr>Sombre</fr>
 			<es>Oscuro</es>

--- a/src/ToDo.UI/Strings/en/Resources.resw
+++ b/src/ToDo.UI/Strings/en/Resources.resw
@@ -168,10 +168,10 @@
   <data name="SettingsPage_ThemeLabel.Text" xml:space="preserve">
     <value>Mode</value>
   </data>
-  <data name="SettingsPage_ThemeLight.Content" xml:space="preserve">
+  <data name="SettingsPage_ThemeLight" xml:space="preserve">
     <value>Light</value>
   </data>
-  <data name="SettingsPage_ThemeDark.Content" xml:space="preserve">
+  <data name="SettingsPage_ThemeDark" xml:space="preserve">
     <value>Dark</value>
   </data>
   <data name="SettingsPage_AboutSection.Text" xml:space="preserve">

--- a/src/ToDo.UI/Strings/es/Resources.resw
+++ b/src/ToDo.UI/Strings/es/Resources.resw
@@ -168,10 +168,10 @@
   <data name="SettingsPage_ThemeLabel.Text" xml:space="preserve">
     <value>Tema</value>
   </data>
-  <data name="SettingsPage_ThemeLight.Content" xml:space="preserve">
+  <data name="SettingsPage_ThemeLight" xml:space="preserve">
     <value>Claro</value>
   </data>
-  <data name="SettingsPage_ThemeDark.Content" xml:space="preserve">
+  <data name="SettingsPage_ThemeDark" xml:space="preserve">
     <value>Oscuro</value>
   </data>
   <data name="SettingsPage_AboutSection.Text" xml:space="preserve">

--- a/src/ToDo.UI/Strings/fr/Resources.resw
+++ b/src/ToDo.UI/Strings/fr/Resources.resw
@@ -168,10 +168,10 @@
   <data name="SettingsPage_ThemeLabel.Text" xml:space="preserve">
     <value>Mode</value>
   </data>
-  <data name="SettingsPage_ThemeLight.Content" xml:space="preserve">
+  <data name="SettingsPage_ThemeLight" xml:space="preserve">
     <value>Clair</value>
   </data>
-  <data name="SettingsPage_ThemeDark.Content" xml:space="preserve">
+  <data name="SettingsPage_ThemeDark" xml:space="preserve">
     <value>Sombre</value>
   </data>
   <data name="SettingsPage_AboutSection.Text" xml:space="preserve">

--- a/src/ToDo.UI/ToDo.UI.projitems
+++ b/src/ToDo.UI/ToDo.UI.projitems
@@ -37,6 +37,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ReferenceConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\StringFormatter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\TaskListToValueConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AppTheme.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReactiveClasses.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\Dialogs\AddListFlyout.xaml.cs">
       <DependentUpon>AddListFlyout.xaml</DependentUpon>

--- a/src/ToDo.UI/Views/HomePage.xaml.cs
+++ b/src/ToDo.UI/Views/HomePage.xaml.cs
@@ -1,6 +1,4 @@
-﻿using Uno.Extensions.Navigation.UI;
-
-namespace ToDo.Views;
+﻿namespace ToDo.Views;
 
 public sealed partial class HomePage : Page
 {

--- a/src/ToDo.UI/Views/SearchPage.xaml.cs
+++ b/src/ToDo.UI/Views/SearchPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿namespace ToDo.Views;
 
-
 public sealed partial class SearchPage : Page
 {
 	public SearchPage()

--- a/src/ToDo.UI/Views/SettingsPage.xaml
+++ b/src/ToDo.UI/Views/SettingsPage.xaml
@@ -104,23 +104,21 @@
 									   Style="{StaticResource BodySmall}" />
 						</utu:AutoLayout>
 						<utu:AutoLayout Spacing="5">
-							<TextBlock x:Uid="SettingsPage_ThemeLabel" 
+							<TextBlock x:Uid="SettingsPage_ThemeLabel"
 									   Foreground="{ThemeResource OnSurfaceBrush}"
 									   Text="Mode"
 									   utu:AutoLayout.CounterAlignment="Start"
 									   Style="{StaticResource TitleMedium}" />
 							<utu:ChipGroup x:Name="ThemeChipGroup"
 										   SelectionMode="Single"
-										   ItemChecked="{x:Bind UpdateAppTheme}"
+										   ItemsSource="{Binding AppThemes}"
+										   SelectedItem="{Binding SelectedAppTheme, Mode=TwoWay}"
 										   Style="{StaticResource FilterChipGroupStyle}">
-								<utu:Chip x:Uid="SettingsPage_ThemeLight"
-										  Content="Light"
-										  Tag="Light"
-										  Style="{StaticResource FilterChipStyle}" />
-								<utu:Chip x:Uid="SettingsPage_ThemeDark"
-										  Content="Dark"
-										  Tag="Dark"
-										  Style="{StaticResource FilterChipStyle}" />
+								<utu:ChipGroup.ItemTemplate>
+									<DataTemplate>
+										<TextBlock Text="{Binding}" />
+									</DataTemplate>
+								</utu:ChipGroup.ItemTemplate>
 							</utu:ChipGroup>
 						</utu:AutoLayout>
 					</utu:AutoLayout>

--- a/src/ToDo.UI/Views/SettingsPage.xaml.cs
+++ b/src/ToDo.UI/Views/SettingsPage.xaml.cs
@@ -1,49 +1,10 @@
-﻿using Uno.Toolkit.UI;
-
-using ChipControl = global::Uno.Toolkit.UI.Chip; // aliasing to prevent collision, since `global::Chip` is a namespace on ios/macos...
-
-namespace ToDo.Views;
+﻿namespace ToDo.Views;
 
 public sealed partial class SettingsPage : Page
 {
-	private SettingsViewModel.BindableSettingsViewModel? ViewModel { get; set; }
-
-	private bool isInitializing;
-
 	public SettingsPage()
 	{
 		this.InitializeComponent();
-
-		DataContextChanged += (sender, contextArgs) =>
-		{
-			this.ViewModel = DataContext as SettingsViewModel.BindableSettingsViewModel;
-			if (this.IsLoaded)
-			{
-				PageLoaded();
-			}
-		};
-
-
-		this.Loaded += (s, e) =>
-		{
-			PageLoaded();
-		};
-	}
-	private void PageLoaded()
-	{
-		if (ViewModel is null)
-		{
-			return;
-		}
-
-		isInitializing = true;
-
-		// Set default theme
-		var currentTheme = SystemThemeHelper.IsRootInDarkMode(XamlRoot) ? "Dark" : "Light";
-		SelectChipGroupItem(ThemeChipGroup, x => (string)x.Tag == currentTheme);
-
-		// Set default theme
-		isInitializing = false;
 	}
 
 	private void UpdateAppColorPalette(object sender, ChipItemEventArgs e)
@@ -61,23 +22,5 @@ public sealed partial class SettingsPage : Page
 
 		//	_ => throw new ArgumentOutOfRangeException(),
 		//}
-	}
-
-	private void UpdateAppTheme(object sender, ChipItemEventArgs e)
-	{
-		if (isInitializing) return;
-
-		if (e.Item is ChipControl chip)
-		{
-			SystemThemeHelper.SetRootTheme(XamlRoot, (string)chip.Tag == "Dark");
-		}
-	}
-
-	private void SelectChipGroupItem(ChipGroup group, Func<ChipControl, bool> predicate)
-	{
-		if (group.Items.Cast<ChipControl>().FirstOrDefault(predicate) is { } item)
-		{
-			group.SelectedItem = item;
-		}
 	}
 }

--- a/src/ToDo.UI/Views/TaskListPage.xaml.cs
+++ b/src/ToDo.UI/Views/TaskListPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿namespace ToDo.Views;
 
-public sealed partial class TaskListPage
+public sealed partial class TaskListPage : Page
 {
 	public TaskListPage()
 	{

--- a/src/ToDo.UI/Views/TaskListPage.xaml.cs
+++ b/src/ToDo.UI/Views/TaskListPage.xaml.cs
@@ -1,43 +1,10 @@
 ﻿namespace ToDo.Views;
 
-public sealed partial class TaskListPage : Page, IInjectable<INavigator>
+public sealed partial class TaskListPage
 {
 	public TaskListPage()
 	{
 		this.InitializeComponent();
 	}
-
-	public async void CreateTaskClick(object sender, RoutedEventArgs args)
-	{
-
-		var response = await Navigator!.NavigateViewModelForResultAsync<AddTaskViewModel, TaskData>(this, qualifier: Qualifiers.Dialog);
-		if (response is null)
-		{
-			return;
-		}
-
-		var result = await response.Result;
-
-		var taskTitle = result.SomeOrDefault()?.Title;
-
-	}
-
-	public async void DeleteListClick(object sender, RoutedEventArgs args)
-	{
-
-		var response = await Navigator!.NavigateRouteForResultAsync< DialogAction>(this, "ConfirmDeleteList", qualifier: Qualifiers.Dialog);
-		if (response is null)
-		{
-			return;
-		}
-
-		var result = await response.Result;
-
-		var actionLabel= result.SomeOrDefault()?.Label;
-
-	}
-
-	private INavigator? Navigator { get; set; }
-	public void Inject(INavigator entity) => Navigator = entity;
 }
 

--- a/src/ToDo/GlobalUsings.cs
+++ b/src/ToDo/GlobalUsings.cs
@@ -22,6 +22,7 @@ global using Microsoft.Extensions.Logging;
 global using Microsoft.Extensions.Options;
 global using Microsoft.Identity.Client;
 global using Refit;
+global using ToDo;
 global using ToDo.Business;
 global using ToDo.Business.Mock;
 global using ToDo.Business.Models;

--- a/src/ToDo/IAppTheme.cs
+++ b/src/ToDo/IAppTheme.cs
@@ -1,6 +1,7 @@
 ﻿namespace ToDo;
 
 // TODO: Extract these to uno extensions
+// See https://github.com/unoplatform/uno.extensions/discussions/420
 public interface IAppTheme
 {
 	bool IsDark { get; }

--- a/src/ToDo/IAppTheme.cs
+++ b/src/ToDo/IAppTheme.cs
@@ -6,5 +6,5 @@ public interface IAppTheme
 {
 	bool IsDark { get; }
 
-	void SetTheme(bool darkMode);
+	Task SetThemeAsync(bool darkMode);
 }

--- a/src/ToDo/IAppTheme.cs
+++ b/src/ToDo/IAppTheme.cs
@@ -1,0 +1,9 @@
+﻿namespace ToDo;
+
+// TODO: Extract these to uno extensions
+public interface IAppTheme
+{
+	bool IsDark { get; }
+
+	void SetTheme(bool darkMode);
+}

--- a/src/ToDo/Presentation/Dialogs/Dialog.cs
+++ b/src/ToDo/Presentation/Dialogs/Dialog.cs
@@ -1,0 +1,8 @@
+﻿namespace ToDo.Presentation.Dialogs;
+
+public static class Dialog
+{
+	public static string ConfirmDeleteList = nameof(ConfirmDeleteList);
+	public static string ConfirmDeleteTask = nameof(ConfirmDeleteTask);
+	public static string ConfirmSignOut = nameof(ConfirmSignOut);
+}

--- a/src/ToDo/Presentation/Dialogs/DialogResults.cs
+++ b/src/ToDo/Presentation/Dialogs/DialogResults.cs
@@ -5,3 +5,20 @@ public static class DialogResults
 	public static object Affirmative = nameof(Affirmative);
 	public static object Negative = nameof(Negative);
 }
+
+public static class Dialog
+{
+	public static string ConfirmDeleteList = nameof(ConfirmDeleteList);
+	public static string ConfirmDeleteTask = nameof(ConfirmDeleteTask);
+	public static string ConfirmSignOut = nameof(ConfirmSignOut);
+}
+
+public static class ResourceKeys
+{
+	public static string WideMinWindowWidth = nameof(WideMinWindowWidth);
+	public static string DialogContent = "Content";
+	public static string DialogTitle = "Title";
+	public static string DeleteButton = "./Dialog_Common_Delete";
+	public static string CancelButton = "./Dialog_Common_Cancel";
+	public static string SignOutButton = "SignOut";
+}

--- a/src/ToDo/Presentation/Dialogs/DialogResults.cs
+++ b/src/ToDo/Presentation/Dialogs/DialogResults.cs
@@ -5,20 +5,3 @@ public static class DialogResults
 	public static object Affirmative = nameof(Affirmative);
 	public static object Negative = nameof(Negative);
 }
-
-public static class Dialog
-{
-	public static string ConfirmDeleteList = nameof(ConfirmDeleteList);
-	public static string ConfirmDeleteTask = nameof(ConfirmDeleteTask);
-	public static string ConfirmSignOut = nameof(ConfirmSignOut);
-}
-
-public static class ResourceKeys
-{
-	public static string WideMinWindowWidth = nameof(WideMinWindowWidth);
-	public static string DialogContent = "Content";
-	public static string DialogTitle = "Title";
-	public static string DeleteButton = "./Dialog_Common_Delete";
-	public static string CancelButton = "./Dialog_Common_Cancel";
-	public static string SignOutButton = "SignOut";
-}

--- a/src/ToDo/Presentation/Dialogs/ResourceKeys.cs
+++ b/src/ToDo/Presentation/Dialogs/ResourceKeys.cs
@@ -1,0 +1,11 @@
+﻿namespace ToDo.Presentation.Dialogs;
+
+public static class ResourceKeys
+{
+	public static string WideMinWindowWidth = nameof(WideMinWindowWidth);
+	public static string DialogContent = "Content";
+	public static string DialogTitle = "Title";
+	public static string DeleteButton = "./Dialog_Common_Delete";
+	public static string CancelButton = "./Dialog_Common_Cancel";
+	public static string SignOutButton = "SignOut";
+}

--- a/src/ToDo/Presentation/SettingsViewModel.cs
+++ b/src/ToDo/Presentation/SettingsViewModel.cs
@@ -32,13 +32,7 @@ public partial class SettingsViewModel
 
 	public async ValueTask SignOut(CancellationToken ct)
 	{
-		var response = await _navigator.NavigateRouteForResultAsync<LocalizableDialogAction>(this, "ConfirmSignOut", qualifier: Qualifiers.Dialog, cancellation: ct);
-		if (response is null)
-		{
-			return;
-		}
-
-		var result = await response.Result;
+		var result = await _navigator.NavigateRouteForResultAsync<LocalizableDialogAction>(this, Dialog.ConfirmSignOut, cancellation: ct).AsResult();
 		if (result.SomeOrDefault()?.Id == DialogResults.Affirmative)
 		{
 			await _authService.SignOutAsync();

--- a/src/ToDo/Presentation/TaskListViewModel.cs
+++ b/src/ToDo/Presentation/TaskListViewModel.cs
@@ -57,13 +57,7 @@ public partial class TaskListViewModel
 	public ICommand DeleteList => Command.Create(c => c.Given(Entity).Then(DoDeleteList));
 	private async ValueTask DoDeleteList(TaskList list, CancellationToken ct)
 	{
-		var response = await _navigator.NavigateRouteForResultAsync<LocalizableDialogAction>(this, "ConfirmDeleteList", qualifier: Qualifiers.Dialog, cancellation: ct);
-		if (response is null)
-		{
-			return;
-		}
-
-		var result = await response.Result;
+		var result = await _navigator.NavigateRouteForResultAsync<LocalizableDialogAction>(this, Dialog.ConfirmDeleteList, cancellation: ct).AsResult();
 		if (result.SomeOrDefault()?.Id == DialogResults.Affirmative)
 		{
 			await _listSvc.DeleteAsync(list, ct);

--- a/src/ToDo/Presentation/TaskViewModel.cs
+++ b/src/ToDo/Presentation/TaskViewModel.cs
@@ -36,13 +36,7 @@ public partial class TaskViewModel
 	public ICommand Delete => Command.Create(b => b.Given(Entity).Then(DoDelete));
 	private async ValueTask DoDelete(ToDoTask task, CancellationToken ct)
 	{
-		var response = await _navigator.NavigateRouteForResultAsync<LocalizableDialogAction>(this, "ConfirmDeleteTask", qualifier: Qualifiers.Dialog, cancellation: ct);
-		if (response is null)
-		{
-			return;
-		}
-
-		var result = await response.Result;
+		var result = await _navigator.NavigateRouteForResultAsync<LocalizableDialogAction>(this, Dialog.ConfirmDeleteTask, cancellation: ct).AsResult();
 		if (result.SomeOrDefault()?.Id == DialogResults.Affirmative)
 		{
 			await _svc.DeleteAsync(task, ct);

--- a/src/ToDo/Settings/ToDoApp.cs
+++ b/src/ToDo/Settings/ToDoApp.cs
@@ -1,0 +1,7 @@
+﻿namespace ToDo.Configuration;
+
+public record ToDoApp
+{
+	public bool? IsDark { get; init; }
+	public string? LastTaskList { get; init; }
+}


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)

## What is the current behavior?

Uses Qualifiers.Dialog to specify that message dialogs should be shown as a dialog
Theme switching is in code behind of settings page and not persisted

## What is the new behavior?

Qualifiers.Dialog is no longer required
Theme switching is done in settingsviewmodel and is persisted between sessions via settings

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
