### PR TITLE
feat: Setting the default task list

### DIFF
--- a/src/ToDo.UI.Tests/ToDo.UI.Tests.csproj
+++ b/src/ToDo.UI.Tests/ToDo.UI.Tests.csproj
@@ -13,7 +13,6 @@
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="Uno.UITest.Helpers" Version="1.1.0-dev.32" />
-		<PackageReference Include="Uno.WinUI.MSAL" Version="4.2.6" />
 		<PackageReference Include="Xamarin.UITest" Version="3.2.6" />
 	</ItemGroup>
 

--- a/src/ToDo.UI/App.xaml.host.cs
+++ b/src/ToDo.UI/App.xaml.host.cs
@@ -1,3 +1,7 @@
+#if DEBUG
+#define USE_MOCKS
+#endif
+
 #pragma warning disable 109 // Remove warning for Window property on iOS
 
 using ToDo.Extensions;

--- a/src/ToDo.UI/Views/HomePage.xaml
+++ b/src/ToDo.UI/Views/HomePage.xaml
@@ -49,6 +49,10 @@
 					<VisualState.StateTriggers>
 						<AdaptiveTrigger MinWindowWidth="0" />
 					</VisualState.StateTriggers>
+					<VisualState.Setters>
+						<Setter Target="NavView.(uen:Navigation.Request)"
+								Value="TaskList" />
+					</VisualState.Setters>
 				</VisualState>
 			</VisualStateGroup>
 		</VisualStateManager.VisualStateGroups>

--- a/src/ToDo.UI/Views/HomePage.xaml
+++ b/src/ToDo.UI/Views/HomePage.xaml
@@ -67,7 +67,9 @@
 							 IsSettingsVisible="False"
 							 Style="{StaticResource HomeNavigationViewStyle}"
 							 CompactModeThresholdWidth="0"
-							 ExpandedModeThresholdWidth="0">
+							 ExpandedModeThresholdWidth="0"
+							 SelectedItem="{Binding SelectedList.Value}"
+							 SelectionChanged="SelectedListChanged">
 
 			<!-- Header: Profile (Setting button) + Search button -->
 			<muxc:NavigationView.PaneHeader>

--- a/src/ToDo.UI/Views/HomePage.xaml.cs
+++ b/src/ToDo.UI/Views/HomePage.xaml.cs
@@ -7,7 +7,7 @@ public sealed partial class HomePage : Page
 		this.InitializeComponent();
 	}
 
-	private async void SelectedListChanged(object sender, NavigationViewSelectionChangedEventArgs args)
+	private void SelectedListChanged(object sender, NavigationViewSelectionChangedEventArgs args)
 	{
 		if(DataContext is HomeViewModel.BindableHomeViewModel vm &&
 			args.SelectedItem is TaskList taskList)

--- a/src/ToDo.UI/Views/HomePage.xaml.cs
+++ b/src/ToDo.UI/Views/HomePage.xaml.cs
@@ -6,4 +6,13 @@ public sealed partial class HomePage : Page
 	{
 		this.InitializeComponent();
 	}
+
+	private async void SelectedListChanged(object sender, NavigationViewSelectionChangedEventArgs args)
+	{
+		if(DataContext is HomeViewModel.BindableHomeViewModel vm &&
+			args.SelectedItem is TaskList taskList)
+		{
+			vm.SelectedListChanged.Execute(taskList);
+		}
+	}
 }

--- a/src/ToDo/Data/Mock/MockTaskListEndpoint.cs
+++ b/src/ToDo/Data/Mock/MockTaskListEndpoint.cs
@@ -2,8 +2,8 @@
 
 public class MockTaskListEndpoint : ITaskListEndpoint
 {
-	private const string ListDataFile = "mock/lists.json";
-	private const string TasksDataFile = "mock/tasks.json";
+	private const string ListDataFile = "Mock/lists.json";
+	private const string TasksDataFile = "Mock/tasks.json";
 
 
 	private readonly ISerializer<TaskListData> _listSerializer;

--- a/src/ToDo/Data/Mock/MockUserProfilePictureEndpoint.cs
+++ b/src/ToDo/Data/Mock/MockUserProfilePictureEndpoint.cs
@@ -2,7 +2,7 @@
 
 internal class MockUserProfilePictureEndpoint : IUserProfilePictureEndpoint
 {
-	private const string ProfilePictureDataFile = "mock/profilePicture.json";
+	private const string ProfilePictureDataFile = "Mock/profilePicture.json";
 
 	private readonly ISerializer<string> _profilePictureSerializer;
 	private readonly IStorage _dataService;


### PR DESCRIPTION
GitHub Issue: #132 

Navigating to Important list, or the last list that the user had opened

## PR Type

What kind of change does this PR introduce?
- Feature
- Bugfix

## What is the current behavior?

- App opens with no task list selected

- Mock files don't load on all platforms
- Mock disabled by default in debug
- Android can't navigate to tasklist

## What is the new behavior?

- App opens the Important task list, or the task list that the user previously had opened

- Mock files now load (path is corrected to be case correct)
- Mock is enabled by default when in DEBUG
- Android (narrow screens) navigation works (except there are other issues with tasklistpage at the moment)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
