### PR TITLE
fix(TaskList): task item alignment

### DIFF
--- a/src/ToDo.UI/Views/TaskListPage.xaml
+++ b/src/ToDo.UI/Views/TaskListPage.xaml
@@ -88,11 +88,13 @@
 												<utu:AutoLayout PrimaryAxisAlignment="Center" utu:AutoLayout.CounterAlignment="Start">
 													<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
 															   Text="{Binding Title}"
+															   MaxLines="1"
 															   utu:AutoLayout.CounterAlignment="Start"
 															   Style="{StaticResource TitleMedium}" />
 													<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
 															   Text="{Binding DueDateTime.DateTime, Converter={StaticResource TaskDueDateFormatter}}"
 															   utu:AutoLayout.CounterAlignment="Start"
+															   Visibility="{Binding DueDateTime.DateTime, Converter={StaticResource IsNotNull}}"
 															   Style="{StaticResource BodyMedium}" />
 												</utu:AutoLayout>
 											</utu:AutoLayout>


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

Task item without a DueDate are still v-centered.
Task item name can no longer span on multiple lines; It will be trimmed to a single line with ellipses.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
<!-- Please provide any additional information if necessary -->