### PR TITLE
fix(slnf): Fixing filtered solution for macOS

### DIFF
--- a/src/ToDo-vsmac.slnf
+++ b/src/ToDo-vsmac.slnf
@@ -4,18 +4,12 @@
     "projects": [
 		"ToDo.UI\\ToDo.UI.shproj",
 
-		"ToDo.Droid\\ToDo.Droid.csproj",
-
-		"ToDo.iOS\\ToDo.iOS.csproj",
-
-
 		"ToDo.Wasm\\ToDo.Wasm.csproj",
-
-		"ToDo.macOS\\ToDo.macOS.csproj",
+		"ToDo\\ToDo.csproj",
+		"ToDo.Mobile\\ToDo.Mobile.csproj",
 
 		"ToDo.Skia.Gtk\\ToDo.Skia.Gtk.csproj",
-
-		"ToDo.Skia.Linux.FrameBuffer\\ToDo.Skia.Linux.FrameBuffer.csproj",
+		"ToDo.Tests\\ToDo.Tests.csproj"
     ]
   }
 }

--- a/src/ToDo.Mobile/MacOS/Info.plist
+++ b/src/ToDo.Mobile/MacOS/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.11</string>
+	<string>10.14</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -26,7 +26,7 @@
 	<string>NSApplication</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
-  <key>ATSApplicationFontsPath</key>
-  <string>Fonts</string>
+	<key>ATSApplicationFontsPath</key>
+	<string>Fonts</string>
 </dict>
 </plist>

--- a/src/ToDo/GlobalUsings.cs
+++ b/src/ToDo/GlobalUsings.cs
@@ -13,6 +13,8 @@ global using System.Text.Json.Serialization;
 global using System.Threading;
 global using System.Threading.Tasks;
 global using System.Windows.Input;
+global using System.Net.Http;
+global using System.IO;
 global using CommunityToolkit.Mvvm.Input;
 global using CommunityToolkit.Mvvm.Messaging;
 global using Microsoft.Extensions.Configuration;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?
- Bugfix
   - Fixing filtered solution for macOS
   - Changing macOS info.plist file to use the min version as 10.14 (Minimum default value)
   - Including System.Net.Http and System.IO on GlobalUsings.cs file


## What is the current behavior?

Currently we can open the slnf file on Visual Studio for Mac or Rider to compile and run the application on macOS system.

## What is the new behavior?

Now we can open the slnf file on Visual Studio for Mac or Rider to compile and run the application on macOS system. 


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
